### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Copyright (c) 2005-2011, Theo Beisch
 Collectively the Copyright Owners  
 All rights reserved.  
 
-##License  
+## License  
 The MIT License (MIT)  
 
 Copyright (c) 2013 Furuyama Takeshi


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
